### PR TITLE
chrome 24 无法打包和导出数据，我已修复

### DIFF
--- a/data/js/made.js
+++ b/data/js/made.js
@@ -81,13 +81,9 @@ function popup_import() {
     fake_click(file);
 }
 function export_raw(name, data) {
-    if (!window.BlobBuilder) {
-        window.BlobBuilder = window.WebKitBlobBuilder;
-    }
     var urlObject = window.URL || window.webkitURL || window;
-    var builder = new BlobBuilder(); 
-    builder.append(data); 
-    var export_blob = builder.getBlob(); 
+
+    var export_blob = new Blob([data]);
 
     var save_link = document.createElementNS("http://www.w3.org/1999/xhtml", "a")
     save_link.href = urlObject.createObjectURL(export_blob);

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -2,6 +2,7 @@
   "name": "MaDe",
   "description": "MaDe Editor for markdown",
   "version": "0.8",
+  "manifest_version": 2,
   "default_locale": "en",
   "app": {
     "launch": {


### PR DESCRIPTION
chrome新版已经强制要把manifest_version设置为2了，另外BlobBuilder也不建议使用了，我换成了Blob。
thx for your Made editor
